### PR TITLE
fix: restore missing export default on category pages

### DIFF
--- a/app/accessories/page.tsx
+++ b/app/accessories/page.tsx
@@ -1,12 +1,13 @@
+import CommingSoon from '@/components/CommingSoon/CommingSoon';
 import { getSEOData } from "@/lib/seo";
 import { buildSeoMetadata } from "@/lib/canonical";
 import { noIndex } from "@/lib/noindex";
 import { Metadata } from "next";
-
 
 export async function generateMetadata(): Promise<Metadata> {
   const seoData = await getSEOData("/accessories");
   return { ...noIndex, ...buildSeoMetadata(seoData, "/accessories") };
 }
 
-
+const page = () => <CommingSoon />;
+export default page;

--- a/app/adults-goods/page.tsx
+++ b/app/adults-goods/page.tsx
@@ -1,12 +1,13 @@
+import CommingSoon from '@/components/CommingSoon/CommingSoon';
 import { getSEOData } from "@/lib/seo";
 import { buildSeoMetadata } from "@/lib/canonical";
 import { noIndex } from "@/lib/noindex";
 import { Metadata } from "next";
-
 
 export async function generateMetadata(): Promise<Metadata> {
   const seoData = await getSEOData("/adults-goods");
   return { ...noIndex, ...buildSeoMetadata(seoData, "/adults-goods") };
 }
 
-
+const page = () => <CommingSoon />;
+export default page;

--- a/app/hookah/page.tsx
+++ b/app/hookah/page.tsx
@@ -1,12 +1,13 @@
+import CommingSoon from '@/components/CommingSoon/CommingSoon';
 import { getSEOData } from "@/lib/seo";
 import { buildSeoMetadata } from "@/lib/canonical";
 import { noIndex } from "@/lib/noindex";
 import { Metadata } from "next";
-
 
 export async function generateMetadata(): Promise<Metadata> {
   const seoData = await getSEOData("/hookah");
   return { ...noIndex, ...buildSeoMetadata(seoData, "/hookah") };
 }
 
-
+const page = () => <CommingSoon />;
+export default page;

--- a/app/supplements/page.tsx
+++ b/app/supplements/page.tsx
@@ -1,12 +1,13 @@
+import CommingSoon from '@/components/CommingSoon/CommingSoon';
 import { getSEOData } from "@/lib/seo";
 import { buildSeoMetadata } from "@/lib/canonical";
 import { noIndex } from "@/lib/noindex";
 import { Metadata } from "next";
-
 
 export async function generateMetadata(): Promise<Metadata> {
   const seoData = await getSEOData("/supplements");
   return { ...noIndex, ...buildSeoMetadata(seoData, "/supplements") };
 }
 
-
+const page = () => <CommingSoon />;
+export default page;


### PR DESCRIPTION
Restore export default page components on accessories, hookah, supplements, adults-goods