### PR TITLE
fix: set unoptimized:true to fix broken images on Vercel

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -2,6 +2,7 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   images: {
+    unoptimized: true,
     remotePatterns: [
       {
         protocol: "https",


### PR DESCRIPTION
Vercel blocks _next/image for Next.js 15.2.4 CVE. Disable optimization to serve images directly.