### PR TITLE
feat: brand pages + navbar + schema slug

### DIFF
--- a/app/api/brands/route.ts
+++ b/app/api/brands/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  try {
+    const brands = await prisma.brand.findMany({
+      orderBy: { name: "asc" },
+    });
+    return NextResponse.json(brands);
+  } catch {
+    return NextResponse.json({ error: "Failed to fetch brands" }, { status: 500 });
+  }
+}

--- a/app/brand/[brandSlug]/page.tsx
+++ b/app/brand/[brandSlug]/page.tsx
@@ -1,0 +1,35 @@
+import BrandPage from "@/components/Brand/BrandPage";
+import { prisma } from "@/lib/prisma";
+import { notFound } from "next/navigation";
+import type { Metadata } from "next";
+import { noIndex } from "@/lib/noindex";
+
+type Props = {
+  params: Promise<{ brandSlug: string }>;
+};
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { brandSlug } = await params;
+  const brand = await prisma.brand.findFirst({ where: { slug: brandSlug } });
+  if (!brand) return { title: "Brand Not Found" };
+  return {
+    ...noIndex,
+    title: `${brand.name} Disposable Vapes | GetSmoke`,
+    description: `Shop all ${brand.name} disposable vapes at GetSmoke. Best prices, fast shipping.`,
+  };
+}
+
+const page = async ({ params }: Props) => {
+  const { brandSlug } = await params;
+  const brand = await prisma.brand.findFirst({ where: { slug: brandSlug } });
+  if (!brand) notFound();
+  return (
+    <BrandPage
+      brandId={brand.id}
+      brandName={brand.name}
+      brandSlug={brandSlug}
+    />
+  );
+};
+
+export default page;

--- a/components/Brand/BrandPage.tsx
+++ b/components/Brand/BrandPage.tsx
@@ -1,0 +1,28 @@
+"use client";
+import React from "react";
+import Products from "@/components/HomePage/Products";
+import Filter from "@/components/HomePage/Filter";
+import Image from "next/image";
+
+interface BrandPageProps {
+  brandId: string;
+  brandName: string;
+  brandSlug: string;
+}
+
+const BrandPage = ({ brandId, brandName, brandSlug }: BrandPageProps) => {
+  return (
+    <main>
+      <div className="w-11/12 mx-auto pt-8 pb-4 font-unbounded">
+        <h1 className="text-3xl font-bold mb-2">{brandName}</h1>
+        <p className="text-gray-500 text-sm mb-6">Shop all {brandName} disposable vapes</p>
+      </div>
+      <div className="pt-2">
+        <Filter />
+        <Products productType="VAPES" brandId={brandId} />
+      </div>
+    </main>
+  );
+};
+
+export default BrandPage;

--- a/components/Navbar/Navbar.tsx
+++ b/components/Navbar/Navbar.tsx
@@ -162,12 +162,16 @@ const Navbar = () => {
     }, [searchQuery, showResults]);
 
     const navItems = [
-        { title: "Main", href: "/" },
-        { title: "Vapes", href: "/vapes" },
-        { title: "Hookah", href: "/hookah" },
-        { title: "Accessories", href: "/accessories" },
+        { title: "Home", href: "/" },
+        { title: "Shop All", href: "/vapes" },
+        { title: "Geek Bar", href: "/brand/geek-bar" },
+        { title: "Lost Mary", href: "/brand/lost-mary" },
+        { title: "RAZ", href: "/brand/raz" },
+        { title: "VIHO", href: "/brand/viho" },
+        { title: "HQD", href: "/brand/hqd" },
+        { title: "FUME", href: "/brand/fume" },
         { title: "Blog", href: "/blog" },
-        { title: "Contact us", href: "/contact" },
+        { title: "Contact", href: "/contact" },
     ];
 
     const handleProductClick = (productSlug: string) => {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -139,6 +139,7 @@ model Nicotine {
 model Brand {
   id        String    @id @default(auto()) @map("_id") @db.ObjectId
   name      String
+  slug      String?
   products  Product[]
   createdAt DateTime  @default(now())
   updatedAt DateTime  @updatedAt


### PR DESCRIPTION
- Brand pages at /brand/[brandSlug]
- Navbar updated with brand links
- Brand model gets slug field
- /api/brands endpoint