### PR TITLE
design: brand pages v2 - no hero, clean headings

### DIFF
--- a/app/brand/[brandSlug]/page.tsx
+++ b/app/brand/[brandSlug]/page.tsx
@@ -11,25 +11,17 @@ type Props = {
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { brandSlug } = await params;
   const brand = await prisma.brand.findFirst({ where: { slug: brandSlug } });
-  if (!brand) return { title: "Brand Not Found" };
+  if (!brand) return { ...noIndex, title: "Brand Not Found" };
   return {
     ...noIndex,
-    title: `${brand.name} Disposable Vapes | GetSmoke`,
-    description: `Shop all ${brand.name} disposable vapes at GetSmoke. Best prices, fast shipping.`,
+    title: `${brand.name} Vapes | GetSmoke`,
+    description: `Shop all ${brand.name} disposable vapes at GetSmoke. Best prices and fast US shipping.`,
   };
 }
 
-const page = async ({ params }: Props) => {
+export default async function BrandSlugPage({ params }: Props) {
   const { brandSlug } = await params;
   const brand = await prisma.brand.findFirst({ where: { slug: brandSlug } });
-  if (!brand) notFound();
-  return (
-    <BrandPage
-      brandId={brand.id}
-      brandName={brand.name}
-      brandSlug={brandSlug}
-    />
-  );
-};
-
-export default page;
+  if (!brand) return notFound();
+  return <BrandPage brandId={brand.id} brandName={brand.name} />;
+}

--- a/app/hookah/page.tsx
+++ b/app/hookah/page.tsx
@@ -1,13 +1,12 @@
-import { getSEOData } from "@/lib/seo";
-import { buildSeoMetadata } from "@/lib/canonical";
 import { noIndex } from "@/lib/noindex";
 import { Metadata } from "next";
 import VapePage from "@/components/vapes/VapePage";
 
-export async function generateMetadata(): Promise<Metadata> {
-  const seoData = await getSEOData("/hookah");
-  return { ...noIndex, ...buildSeoMetadata(seoData, "/hookah") };
-}
+export const metadata: Metadata = {
+  ...noIndex,
+  title: "Hookah & E-Hookah | GetSmoke",
+  description: "Shop hookah, e-hookah and shisha vapes at GetSmoke.",
+};
 
 export default function HookahPage() {
   return <VapePage productType="HOOKAH" />;

--- a/app/vapes/page.tsx
+++ b/app/vapes/page.tsx
@@ -9,5 +9,18 @@ export async function generateMetadata(): Promise<Metadata> {
   return { ...noIndex, ...buildSeoMetadata(seoData, "/vapes") };
 }
 
-const page = () => <VapePage />;
-export default page;
+export default function VapesPage() {
+  return (
+    <main>
+      <div className="w-11/12 mx-auto pt-8 pb-4">
+        <h1 className="font-unbounded font-bold text-2xl md:text-3xl uppercase">
+          All Disposable <span style={{ color: "#fe3500" }}>Vapes</span>
+        </h1>
+        <p className="text-sm text-gray-500 mt-1">
+          Shop our full collection of disposable vapes at GetSmoke
+        </p>
+      </div>
+      <VapePage productType="VAPES" />
+    </main>
+  );
+}

--- a/components/Brand/BrandPage.tsx
+++ b/components/Brand/BrandPage.tsx
@@ -1,37 +1,39 @@
-"use client";
-import React, { useEffect } from "react";
-import Products from "@/components/HomePage/Products";
-import Filter from "@/components/HomePage/Filter";
-import { useFilter } from "@/hooks/useFilter";
+"use client"
+import React, { useEffect } from "react"
+import Products from "../HomePage/Products"
+import Filter from "../HomePage/Filter"
+import { useFilter } from "@/hooks/useFilter"
 
 interface BrandPageProps {
-  brandId: string;
-  brandName: string;
-  brandSlug: string;
+    brandId: string;
+    brandName: string;
 }
 
 const BrandPage = ({ brandId, brandName }: BrandPageProps) => {
-  const { setFilters, clearFilters } = useFilter();
+    const { setFilters } = useFilter();
 
-  useEffect(() => {
-    setFilters({ brandId });
-    return () => clearFilters();
-  }, [brandId]);
+    useEffect(() => {
+        setFilters({ brandId });
+        return () => setFilters({ brandId: undefined });
+    }, [brandId, setFilters]);
 
-  return (
-    <main>
-      <div className="w-11/12 mx-auto pt-8 pb-4 font-unbounded">
-        <h1 className="text-3xl font-bold mb-2">{brandName}</h1>
-        <p className="text-gray-500 text-sm mb-6">
-          Shop all {brandName} disposable vapes
-        </p>
-      </div>
-      <div className="pt-2">
-        <Filter />
-        <Products productType="VAPES" />
-      </div>
-    </main>
-  );
-};
+    return (
+        <main>
+            {/* Brand header — no hero, clean heading */}
+            <div className="w-11/12 mx-auto pt-8 pb-4">
+                <h1 className="font-unbounded font-bold text-2xl md:text-3xl uppercase">
+                    {brandName} <span style={{ color: "#fe3500" }}>Vapes</span>
+                </h1>
+                <p className="text-sm text-gray-500 mt-1">
+                    Shop all {brandName} disposable vapes at GetSmoke
+                </p>
+            </div>
+            <div className="pt-2">
+                <Filter />
+                <Products productType="VAPES" />
+            </div>
+        </main>
+    )
+}
 
-export default BrandPage;
+export default BrandPage

--- a/components/vapes/VapePage.tsx
+++ b/components/vapes/VapePage.tsx
@@ -1,6 +1,5 @@
 "use client"
 import React from 'react'
-import Hero from './Hero'
 import Products from '../HomePage/Products'
 import Filter from '../HomePage/Filter'
 
@@ -11,8 +10,7 @@ interface VapePageProps {
 const VapePage = ({ productType = "VAPES" }: VapePageProps) => {
     return (
         <main>
-            <Hero />
-            <div className='pt-5'>
+            <div className="pt-2">
                 <Filter />
                 <Products productType={productType} />
             </div>


### PR DESCRIPTION
Remove hero from brand pages. Add brand-specific heading. Clean up vapes/hookah pages.